### PR TITLE
HTML title fixed as suggested in issue #3 - Page Title Suggestion

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -66,7 +66,6 @@ function runTest() {
 
         test_subtitle_node.textContent = test_success ? "Your Internet is Working!" : "Something's Wrong!";
         test_in_progress = false;
-        
         document.title = `${test_status} ${test_subtitle_node.textContent}`;
 
         clearTimeout(auto_test.timeout);

--- a/src/app.js
+++ b/src/app.js
@@ -66,7 +66,8 @@ function runTest() {
 
         test_subtitle_node.textContent = test_success ? "Your Internet is Working!" : "Something's Wrong!";
         test_in_progress = false;
-        document.title = `${PAGE_BASE_TITLE} ${test_status}`;
+        
+        document.title = `${test_status} ${test_subtitle_node.textContent}`;
 
         clearTimeout(auto_test.timeout);
         if (auto_test.rate > 0) auto_test.timeout = setTimeout(runTest, auto_test.rate * 1000);


### PR DESCRIPTION
Basically it was a suggestion which is converted in to pull request.

Instead of HTML title "Is My Internet Working? YES/NO", show "YES! Your Internet is Working!" or  "NO! Something's Wrong! "

Why I'm doing this? When we have too many tabs in the browser, we can't see this YES/NO. We have to move mouse over the tab or open it.